### PR TITLE
Implement 180-rotations (experimental)

### DIFF
--- a/finesse.io/index.html
+++ b/finesse.io/index.html
@@ -64,8 +64,15 @@
                 <td>0</td>
             </tr>
             <tr>
-                <td>Hold</td>
+                <td>180 Rotation (experimental)</td>
                 <td>[C]</td>
+                <td>Square</td>
+                <td>X</td>
+                <td>2</td>
+            </tr>
+            <tr>
+                <td>Hold</td>
+                <td>[Space]</td>
                 <td>R1</td>
                 <td>RB</td>
                 <td>5</td>

--- a/finesse.io/scripts/grids/minos.js
+++ b/finesse.io/scripts/grids/minos.js
@@ -225,5 +225,5 @@ getOffsets = function(index, srcOrientation, dstOrientation)
                break;
         }
     }
-    return [0,0];
+    return [[0,0]];
 };

--- a/finesse.io/scripts/main.js
+++ b/finesse.io/scripts/main.js
@@ -22,6 +22,7 @@ const KEY_RIGHT = 'RIGHT';
 const KEY_DOWN = 'SOFT_DROP';
 const KEY_CLOCK = 'ROTATE_C';
 const KEY_COUNTERCLOCK = 'ROTATE_CC';
+const KEY_180 = '180';
 const KEY_HOLD =  'HOLD';
 const KEY_MODE = 'MODE';
 const KEY_RESET = 'START';
@@ -46,7 +47,8 @@ var defaultKeyboardBindings = [
     ['arrowright', KEY_RIGHT],
     ['keyx', KEY_CLOCK],
     ['keyz', KEY_COUNTERCLOCK],
-    ['keyc', KEY_HOLD],
+    ['keyc', KEY_180],
+    ['space', KEY_HOLD],
     ['escape', KEY_RESET],
     ['tab', KEY_MODE]
 ];
@@ -57,7 +59,8 @@ var keyboardBindings = [
     ['arrowright', KEY_RIGHT],
     ['keyx', KEY_CLOCK],
     ['keyz', KEY_COUNTERCLOCK],
-    ['keyc', KEY_HOLD],
+    ['keyc', KEY_180],
+    ['space', KEY_HOLD],
     ['escape', KEY_RESET],
     ['tab', KEY_MODE]
 ];
@@ -68,6 +71,7 @@ var defaultControllerBindings = [
     [15, KEY_RIGHT],
     [1, KEY_CLOCK],
     [0, KEY_COUNTERCLOCK],
+    [2, KEY_180],
     [5, KEY_HOLD],
     [8, KEY_RESET],
     [9, KEY_MODE]
@@ -79,6 +83,7 @@ var controllerBindings = [
     [15, KEY_RIGHT],
     [1, KEY_CLOCK],
     [0, KEY_COUNTERCLOCK],
+    [2, KEY_180],
     [5, KEY_HOLD],
     [8, KEY_RESET],
     [9, KEY_MODE]
@@ -131,6 +136,7 @@ var gameMode = 0;
         var BORDER = -2;
         var clockwise = 1;
         var counterclockwise = -1;
+        var rotate180 = 0;
  
         var fallingShape;
         var dim = 640;
@@ -265,11 +271,15 @@ var playerArrSetting;
             var tempShape = new Shape(s.x, s.y, s.matrix, s.ordinal, s.orientation);
             if (direction === clockwise){
                rotateClockwise(tempShape);
-           } else {
+           } else if (direction === counterclockwise) {
                rotateCounterClockwise(tempShape);
+           } else if (direction === rotate180)
+           {
+               console.log("180!");
+               rotateClockwise(tempShape);
+               rotateClockwise(tempShape);
            }
-            
-            
+           
             var offsets = getOffsets(fallingShape.ordinal, fallingShape.orientation, tempShape.orientation);
             var tests = new Array(offsets.length);
             for (var i = 0; i < offsets.length; i++)
@@ -310,8 +320,12 @@ var playerArrSetting;
  
             if (direction === clockwise){
                rotateClockwise(s);
-           } else {
+           } else if (direction === counterclockwise){
                rotateCounterClockwise(s);
+           } else if (direction === rotate180)
+           {
+               rotateClockwise(s);
+               rotateClockwise(s);
            }
         }
  
@@ -1385,6 +1399,7 @@ function exportSettings()
                 KEY_RIGHT: getKeyboardInputForCode(KEY_RIGHT),
                 KEY_CLOCK: getKeyboardInputForCode(KEY_CLOCK),
                 KEY_COUNTERCLOCK: getKeyboardInputForCode(KEY_COUNTERCLOCK),
+                KEY_180: getKeyboardInputForCode(KEY_180),
                 KEY_HOLD: getKeyboardInputForCode(KEY_HOLD),
                 KEY_RESET: getKeyboardInputForCode(KEY_RESET),
                 KEY_MODE: getKeyboardInputForCode(KEY_MODE)
@@ -1397,6 +1412,7 @@ function exportSettings()
                 KEY_RIGHT: getControllerInputForCode(KEY_RIGHT),
                 KEY_CLOCK: getControllerInputForCode(KEY_CLOCK),
                 KEY_COUNTERCLOCK: getControllerInputForCode(KEY_COUNTERCLOCK),
+                KEY_180: getControllerInputForCode(KEY_180),
                 KEY_HOLD: getControllerInputForCode(KEY_HOLD),
                 KEY_RESET: getControllerInputForCode(KEY_RESET),
                 KEY_MODE: getControllerInputForCode(KEY_MODE)
@@ -1439,6 +1455,7 @@ function importSettings(settings)
         keyboardBindings.push([keybinds.KEY_RIGHT, KEY_RIGHT]);
         keyboardBindings.push([keybinds.KEY_CLOCK, KEY_CLOCK]);
         keyboardBindings.push([keybinds.KEY_COUNTERCLOCK, KEY_COUNTERCLOCK]);
+        keyboardBindings.push([keybinds.KEY_180, KEY_180]);
         keyboardBindings.push([keybinds.KEY_HOLD, KEY_HOLD]);
         keyboardBindings.push([keybinds.KEY_MODE, KEY_MODE]);
         keyboardBindings.push([keybinds.KEY_RESET, KEY_RESET]);
@@ -1455,6 +1472,7 @@ function importSettings(settings)
         controllerBindings.push([keybinds.KEY_RIGHT, KEY_RIGHT]);
         controllerBindings.push([keybinds.KEY_CLOCK, KEY_CLOCK]);
         controllerBindings.push([keybinds.KEY_COUNTERCLOCK, KEY_COUNTERCLOCK]);
+        controllerBindings.push([keybinds.KEY_180, KEY_180]);
         controllerBindings.push([keybinds.KEY_HOLD, KEY_HOLD]);
         controllerBindings.push([keybinds.KEY_MODE, KEY_MODE]);
         controllerBindings.push([keybinds.KEY_RESET, KEY_RESET]);
@@ -1511,6 +1529,7 @@ function saveSettings()
                 KEY_RIGHT: getKeyboardInputForCode(KEY_RIGHT),
                 KEY_CLOCK: getKeyboardInputForCode(KEY_CLOCK),
                 KEY_COUNTERCLOCK: getKeyboardInputForCode(KEY_COUNTERCLOCK),
+                KEY_180: getKeyboardInputForCode(KEY_180),
                 KEY_HOLD: getKeyboardInputForCode(KEY_HOLD),
                 KEY_RESET: getKeyboardInputForCode(KEY_RESET),
                 KEY_MODE: getKeyboardInputForCode(KEY_MODE)
@@ -1523,6 +1542,7 @@ function saveSettings()
                 KEY_RIGHT: getControllerInputForCode(KEY_RIGHT),
                 KEY_CLOCK: getControllerInputForCode(KEY_CLOCK),
                 KEY_COUNTERCLOCK: getControllerInputForCode(KEY_COUNTERCLOCK),
+                KEY_180: getControllerInputForCode(KEY_180),
                 KEY_HOLD: getControllerInputForCode(KEY_HOLD),
                 KEY_RESET: getControllerInputForCode(KEY_RESET),
                 KEY_MODE: getControllerInputForCode(KEY_MODE)

--- a/finesse.io/scripts/scenes/game-scene.js
+++ b/finesse.io/scripts/scenes/game-scene.js
@@ -503,6 +503,17 @@ class GameScene extends Scene
                     moveList.push(ROTATE_COUNTER);
                 }
                 break;
+            case KEY_180:
+                if (curr && !prev)
+                {
+                    if (canRotate(fallingShape, rotate180))
+                    {
+                        rotate(fallingShape, rotate180);
+                    }
+                    moveList.push(ROTATE_CLOCK);
+                    moveList.push(ROTATE_CLOCK);
+                }
+                break;
             case KEY_HOLD:
 
                 if (curr && !prev)

--- a/finesse.io/scripts/scenes/settings-scene.js
+++ b/finesse.io/scripts/scenes/settings-scene.js
@@ -17,11 +17,11 @@ limitations under the License.
 class SettingsScene extends Scene{
     
     bindsBox = {
-        x: 100, y: 25, h: 295, w: 440
+        x: 100, y: 25, h: 325, w: 440
     };
     
     keyboardBindsBox = {
-        x: 340, y: 25, h: 295, w: 100
+        x: 340, y: 25, h: 325, w: 100
     };
     
     leftKeyBindBox = {
@@ -42,44 +42,47 @@ class SettingsScene extends Scene{
     counterclockwiseKeyBindBox = {
         x: 340, y: 200, h: 30, w:200
     }; 
+    rotate180KeyBindBox = {
+        x: 340, y: 230, h: 30, w:200
+    }; 
     
     holdKeyBindBox = {
-        x: 340, y: 230, h: 30, w:200
+        x: 340, y: 260, h: 30, w:200
     };
     gameModeKeyBindBox = {
-        x: 340, y: 260, h: 30, w:200
+        x: 340, y: 290, h: 30, w:200
     }; 
     newGameKeyBindBox = {
-        x: 340, y: 290, h: 30, w:200
+        x: 340, y: 320, h: 30, w:200
     }; 
     
     controllerBindsBox  = {
-        x: 440, y: 25, h: 295, w: 100
+        x: 440, y: 25, h: 325, w: 100
     };
     
     settingsBox = {
-        x: 100, y: 330, h: 200, w: 440
+        x: 100, y: 375, h: 180, w: 440
     };
     
     dasSettingBox = {
-        x: 340, y: 350, w: 200, h:30
+        x: 340, y: 375, w: 200, h:30
     };
     arrSettingBox = {
-        x: 340, y: 380, w: 200, h:30
+        x: 340, y: 405, w: 200, h:30
     };
     sdrSettingBox = {
-        x: 340, y: 410, w: 200, h:30
+        x: 340, y: 435, w: 200, h:30
     };
     
     masterModeSettingsBox = {
-        x: 340, y: 440, w: 200, h:30
+        x: 340, y: 465, w: 200, h:30
    };
     
     retryOnFinesseSettingsBox = {
-        x: 340, y: 470, w: 200, h:30
+        x: 340, y: 495, w: 200, h:30
    };
     showGhostSettingsBox = {
-        x: 340, y: 500, w: 200, h:30
+        x: 340, y: 525, w: 200, h:30
    };
    
     returnButtonBox = {
@@ -125,9 +128,10 @@ class SettingsScene extends Scene{
         fillRect(this.hardDropKeyBindBox, "#004400");
         fillRect(this.clockwiseKeyBindBox, "#00AA00");
         fillRect(this.counterclockwiseKeyBindBox, "#004400");
-        fillRect(this.holdKeyBindBox, "#00AA00");
-        fillRect(this.gameModeKeyBindBox, "#004400");
-        fillRect(this.newGameKeyBindBox, "#00AA00");
+        fillRect(this.rotate180KeyBindBox, "#00AA00");
+        fillRect(this.holdKeyBindBox, "#004400");
+        fillRect(this.gameModeKeyBindBox, "#00AA00");
+        fillRect(this.newGameKeyBindBox, "#004400");
         
         // game settings
         fillRect(this.dasSettingBox, "#004400");
@@ -175,6 +179,9 @@ class SettingsScene extends Scene{
         g.fillText("COUNTERCLOCKWISE", this.bindsBox.x + bindOffset, this.counterclockwiseKeyBindBox.y + 20);
         g.fillText(getKeyboardInputForCode(KEY_COUNTERCLOCK), this.keyboardBindsBox.x , this.counterclockwiseKeyBindBox.y + 20);
         g.fillText(getControllerInputForCode(KEY_COUNTERCLOCK), this.controllerBindsBox.x + 25, this.counterclockwiseKeyBindBox.y + 20);
+        g.fillText("ROTATE 180", this.bindsBox.x + bindOffset, this.rotate180KeyBindBox.y + 20);
+        g.fillText(getKeyboardInputForCode(KEY_180), this.keyboardBindsBox.x , this.rotate180KeyBindBox.y + 20);
+        g.fillText(getControllerInputForCode(KEY_180), this.controllerBindsBox.x + 25, this.rotate180KeyBindBox.y + 20);
         g.fillText("HOLD", this.bindsBox.x + bindOffset, this.holdKeyBindBox.y + 20);
         g.fillText(getKeyboardInputForCode(KEY_HOLD), this.keyboardBindsBox.x , this.holdKeyBindBox.y + 20);
         g.fillText(getControllerInputForCode(KEY_HOLD), this.controllerBindsBox.x + 25, this.holdKeyBindBox.y + 20);
@@ -308,6 +315,15 @@ class SettingsScene extends Scene{
         {
            this.binding = true;
            this.bindingKey = KEY_COUNTERCLOCK;
+           if (offX > this.controllerBindsBox.x)
+               this.bindingKeyboard = false;
+           else
+               this.bindingKeyboard = true;
+        }   
+        if (isWithinBoundingBox(offX, offY, this.rotate180KeyBindBox))
+        {
+           this.binding = true;
+           this.bindingKey = KEY_180;
            if (offX > this.controllerBindsBox.x)
                this.bindingKeyboard = false;
            else


### PR DESCRIPTION
This adds basic support for 180 rotations
- Please do note that because 180 rotations are not guideline, the kick-tables and offsets are not populated, meaning 180 kicks which work in some games may not work at all.
- Users may need to bind the 180 rotation key if they've used this tool in the past.